### PR TITLE
Handle manifest read errors in app creation

### DIFF
--- a/manifest_api/app.py
+++ b/manifest_api/app.py
@@ -12,8 +12,13 @@ def create_app(manifest_path: str) -> FastAPI:
     def health():
         return {"ok": True}
 
-    with open(manifest_path, "r", encoding="utf-8") as f:
-        manifest = ujson.load(f)
+    try:
+        with open(manifest_path, "r", encoding="utf-8") as f:
+            manifest = ujson.load(f)
+    except FileNotFoundError as e:
+        raise RuntimeError(f"Manifest file not found: {manifest_path}") from e
+    except ValueError as e:
+        raise RuntimeError(f"Failed to decode manifest JSON: {e}") from e
 
     for entity in manifest.get("entities", []):
         CreateModel, UpdateModel, OutModel = make_models(entity)


### PR DESCRIPTION
### **User description**
## Summary
- guard manifest loading with error handling

## Testing
- `python -m py_compile manifest_api/app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f9a35d6c083228e956d562906f111


___

### **PR Type**
Bug fix


___

### **Description**
- Add error handling for manifest file operations

- Catch FileNotFoundError and ValueError exceptions

- Provide descriptive error messages for debugging


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["manifest_path"] --> B["try: open file"]
  B --> C["load JSON"]
  C --> D["create models & routers"]
  B --> E["FileNotFoundError"]
  B --> F["ValueError"]
  E --> G["RuntimeError: file not found"]
  F --> H["RuntimeError: JSON decode failed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>app.py</strong><dd><code>Add manifest file error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

manifest_api/app.py

<ul><li>Wrap manifest file reading in try-except block<br> <li> Handle FileNotFoundError with descriptive error message<br> <li> Handle ValueError for JSON parsing errors<br> <li> Convert exceptions to RuntimeError with context</ul>


</details>


  </td>
  <td><a href="https://github.com/yusufsahin/python-manifest-note-app/pull/1/files#diff-2612bd3ceb4cf9e1205d555a709f415a8c0a265f5029b40e45a1546aa2bf5641">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

