### PR TITLE
Raise error for unsupported field types

### DIFF
--- a/manifest_api/runtime.py
+++ b/manifest_api/runtime.py
@@ -15,7 +15,9 @@ TYPE_MAP = {
 def _pydantic_field(f: Dict[str, Any]) -> Tuple[str, tuple]:
     name = f["name"]
     typ = f.get("type", "string")
-    py_type = TYPE_MAP.get(typ, str)
+    if typ not in TYPE_MAP:
+        raise ValueError(f"Unknown field type '{typ}' for field '{name}'")
+    py_type = TYPE_MAP[typ]
 
     required = f.get("required", False)
     default = None if not required else ...


### PR DESCRIPTION
### **User description**
## Summary
- raise a `ValueError` when encountering an unknown field type in `_pydantic_field`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f9a44f7908322a10dc87754df1124


___

### **PR Type**
Bug fix


___

### **Description**
- Replace silent fallback with explicit error for unknown field types

- Improve error handling in `_pydantic_field` function


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Field Type Check"] --> B{"Type in TYPE_MAP?"}
  B -->|No| C["Raise ValueError"]
  B -->|Yes| D["Return Python Type"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtime.py</strong><dd><code>Add error handling for unknown field types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

manifest_api/runtime.py

<ul><li>Replace silent fallback to <code>str</code> with explicit <code>ValueError</code><br> <li> Add validation check for unknown field types<br> <li> Improve error message with field name and type</ul>


</details>


  </td>
  <td><a href="https://github.com/yusufsahin/python-manifest-note-app/pull/2/files#diff-3e63513ff7936a606de64c25dcfac88c651e08fbd1b204bd04aef792d7bbe0d3">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

