### PR TITLE
Validate manifest file existence in CLI

### DIFF
--- a/manifest_api/cli.py
+++ b/manifest_api/cli.py
@@ -10,6 +10,10 @@ def main():
     p.add_argument("--reload", action="store_true")
     args = p.parse_args()
 
+    if not os.path.isfile(args.manifest):
+        print(f"Manifest file not found: {args.manifest}", file=sys.stderr)
+        sys.exit(1)
+
     app = create_app(args.manifest)
     uvicorn.run(app, host=args.host, port=args.port, reload=args.reload)
 


### PR DESCRIPTION
### **User description**
## Summary
- exit with descriptive error if manifest file is missing when running CLI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f9a3a4a288322b8c74d48571bcc51


___

### **PR Type**
Enhancement


___

### **Description**
- Add manifest file existence validation in CLI

- Exit with descriptive error message if file missing

- Improve error handling for invalid manifest paths


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CLI Arguments"] --> B["Validate Manifest File"]
  B --> C{"File Exists?"}
  C -->|No| D["Print Error & Exit"]
  C -->|Yes| E["Create App & Run Server"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli.py</strong><dd><code>Add manifest file validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

manifest_api/cli.py

<ul><li>Add file existence check for manifest argument<br> <li> Print error message to stderr if file not found<br> <li> Exit with status code 1 on missing file</ul>


</details>


  </td>
  <td><a href="https://github.com/yusufsahin/python-manifest-note-app/pull/6/files#diff-93a0e49c9415adcb119d03c014b04cec95c655e168ab9f562cfc44486d07e5d0">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

